### PR TITLE
Convert hexstring to bytes before using

### DIFF
--- a/csr-gen.py
+++ b/csr-gen.py
@@ -158,8 +158,7 @@ if raa == 0:
 else:
 #	print("RAA: ", raa)
 #	print("HDA: ", hda)
-	hi = public_bytes.hex()
-	det = det_orchid(raa, hda, bytes(hi, 'utf-8'))
+	det = det_orchid(raa, hda, public_bytes)
 	det_int = int(bytes(det, 'utf-8'),16)
 	#print("here", type(det), det)
 	#print("here2", type(det_int), det_int)

--- a/endorse.py
+++ b/endorse.py
@@ -243,7 +243,7 @@ vnatime = time.mktime(tuple)
 
 pleasesign = hex(int(vnbtime))[2:].zfill(8) + hex(int(vnatime))[2:].zfill(8) + clientdet.zfill(32) + client_hihex.zfill(64) + cadet
 #print(pleasesign)
-pleasesignb = bytes(pleasesign, 'utf-8')
+pleasesignb = bytes.fromhex(pleasesign) 
 #print(type(pleasesignb),pleasesignb)
 signature = ca_prkey.sign(pleasesignb)
 #print(type(signature.hex()),signature.hex())
@@ -334,4 +334,3 @@ certificate = builder.sign(ca_prkey, None)
 
 with open(clientpem + "pkix.pem", "wb") as f:
 	f.write(certificate.public_bytes(serialization.Encoding.PEM))
-


### PR DESCRIPTION
This PR fixes the problem of code accidentally using hexstring instead
of the bytes represented by the hexstring.

Fixes #4