### PR TITLE
Make VNA and VNB timestamps RFC 9575 compliant

### DIFF
--- a/endorse.py
+++ b/endorse.py
@@ -46,6 +46,7 @@ __version__ = '2025-03-18'
 
 import sys, getopt
 import ipaddress
+import struct
 import time
 import calendar
 import datetime
@@ -237,15 +238,16 @@ elementb = datetime.datetime.strptime(vnb.strip(),"%m/%d/%Y")
 tuple = elementb.timetuple()
 vnbtime = calendar.timegm(tuple) - DRIP_TIMESTAMP_EPOCH
 #print(type(vnbtime), vnbtime)
-vnbh = hex(int(vnbtime))[2:]
+vnbh = struct.pack("<I", int(vnbtime)).hex()
 #print(vnb, len(vnbh), vnbh)
 
 elementa = datetime.datetime.strptime(vna.strip(),"%m/%d/%Y")
 tuple = elementa.timetuple()
 vnatime = calendar.timegm(tuple) - DRIP_TIMESTAMP_EPOCH
+vnah = struct.pack("<I", int(vnatime)).hex()
 #print(vna, hex(int(vnatime))[2:].zfill(8))
 
-pleasesign = hex(int(vnbtime))[2:].zfill(8) + hex(int(vnatime))[2:].zfill(8) + clientdet.zfill(32) + client_hihex.zfill(64) + cadet
+pleasesign = vnbh + vnah + clientdet.zfill(32) + client_hihex.zfill(64) + cadet
 #print(pleasesign)
 pleasesignb = bytes(pleasesign, 'utf-8')
 #print(type(pleasesignb),pleasesignb)

--- a/endorse.py
+++ b/endorse.py
@@ -47,6 +47,7 @@ __version__ = '2025-03-18'
 import sys, getopt
 import ipaddress
 import time
+import calendar
 import datetime
 import random
 from binascii import *
@@ -131,6 +132,9 @@ selfsign = False
 entitycert = True
 
 # will derive CA DET from RAA, HDA, etc.
+
+DRIP_TIMESTAMP_EPOCH = 1546300800
+
 raa = 16376
 hda = 16376
 
@@ -231,14 +235,14 @@ print("Client HI:", client_hihex)
 
 elementb = datetime.datetime.strptime(vnb.strip(),"%m/%d/%Y")
 tuple = elementb.timetuple()
-vnbtime = time.mktime(tuple)
+vnbtime = calendar.timegm(tuple) - DRIP_TIMESTAMP_EPOCH
 #print(type(vnbtime), vnbtime)
 vnbh = hex(int(vnbtime))[2:]
 #print(vnb, len(vnbh), vnbh)
 
 elementa = datetime.datetime.strptime(vna.strip(),"%m/%d/%Y")
 tuple = elementa.timetuple()
-vnatime = time.mktime(tuple)
+vnatime = calendar.timegm(tuple) - DRIP_TIMESTAMP_EPOCH
 #print(vna, hex(int(vnatime))[2:].zfill(8))
 
 pleasesign = hex(int(vnbtime))[2:].zfill(8) + hex(int(vnatime))[2:].zfill(8) + clientdet.zfill(32) + client_hihex.zfill(64) + cadet


### PR DESCRIPTION
This PR makes the VNA and VNB timestamps RFC 9575 compliant. 

_"In ASTM F3411 timestamps are a Unix-style timestamp with an epoch of 
2019-01-01 00:00:00 UTC. For DRIP, this format is adopted for Authentication 
to keep a common time format in Broadcast payloads."_

and

_"Signature over concatenation of preceding fields (VNB, VNA, DET of Child, 
HI of Child, and DET of Parent) using the keypair of the Parent DET."_

After merging the scripts will use custom epoch of 1546300800 and UTC timezone 
when creating timestamps. Also changes the wire format of the timestamp to 
little endian as required by ASTM F3411.

Fixes #5.