### PR TITLE
Assume orchid left input is bitstring instead of hexstring

### DIFF
--- a/csr-gen.py
+++ b/csr-gen.py
@@ -43,7 +43,7 @@ def det_orchid(raa, hda, hi):
 #	print("HID:", b_hid)
 
 	# perform hash with cSHAKE using input data
-	h_orchid_left = unhexlify(b_prefix + b_hid + b_ogaid)
+	h_orchid_left = bytes.fromhex(hex(int(b_prefix + b_hid + b_ogaid, 2))[2:])
 #	print(h_orchid_left.hex())
 	shake =  cSHAKE128.new(custom = ContextID)
 #	print(type(h_orchid_left))

--- a/det-gen.py
+++ b/det-gen.py
@@ -45,7 +45,7 @@ def det_orchid(keyname, raa, hda, hi):
 #	print("HID:", b_hid)
 
 	# perform hash with cSHAKE using input data
-	h_orchid_left = unhexlify(b_prefix + b_hid + b_ogaid)
+	h_orchid_left = bytes.fromhex(hex(int(b_prefix + b_hid + b_ogaid, 2))[2:])
 #	print(h_orchid_left.hex())
 	shake =  cSHAKE128.new(custom = ContextID)
 	shake.update((h_orchid_left + hi))


### PR DESCRIPTION
This PR fixes the problem of code accidentally trying to unhexlify a 
bitstring instead of hexstring.

Uses `hex(...)[2:]` to match surrounding code.

Fixes #6